### PR TITLE
Fix for undefined is not an object (evaluating NativeModules.RNI18n) …

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let { Platform, NativeModules } = require('react-native')
+import { Platform, NativeModules } from 'react-native';
 let { RNI18n } = NativeModules
 let I18n = require('./vendor/i18n')
 


### PR DESCRIPTION
…with React Native 0.26.0


