### PR TITLE
Remove peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,4 @@
   "devDependencies": {
     "react-native": "^0.5.0"
   },
-  "peerDependencies": {
-    "react-native": ">=0.4.0 <1.0.0"
-  }
 }


### PR DESCRIPTION
Hi everyone, 

Since the last version of react-native -> 0.31.0-rc.1, I got a warning with the peer dependency due to the new name of the version, so, I think to avoid future problems with the react-native version it's better to remove the peer decency. What do you think ?