### PR TITLE
Fix #18: Replace currentLocale with prefered languages

### DIFF
--- a/RNI18n/RNI18n.m
+++ b/RNI18n/RNI18n.m
@@ -16,7 +16,7 @@
 RCT_EXPORT_MODULE();
 
 -(NSString*) getCurrentLocale{
-    NSString *localeString=[[NSLocale currentLocale] localeIdentifier];
+    NSString *localeString=[[NSLocale preferredLanguages] objectAtIndex:0];
     return localeString;
 }
 


### PR DESCRIPTION
On the iOS device the currentLocale returns the region instead of the device language. By using prefered language this is fixed.