### PR TITLE
Fixed broken formatting in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-<img src="https://cdn0.iconfinder.com/data/icons/material-design-ii-glyph/614/3010_-_Translate-512.png" width="110" align="left">
+<img src="https://cdn0.iconfinder.com/data/icons/material-design-ii-glyph/614/3010_-_Translate-512.png" width="110" align="left" />
+
 # react-native-i18n
 Integrates [I18n.js](https://github.com/fnando/i18n-js) with React Native. Uses the device's locale as default.
 <br/>


### PR DESCRIPTION
The top of the README was not rendering properly without this change.

Before:

<img width="956" alt="screen shot 2017-05-23 at 4 19 28 pm" src="https://cloud.githubusercontent.com/assets/139536/26347412/b5e24094-3fd3-11e7-8224-a7afc84b5ba6.png">


After:

<img width="935" alt="screen shot 2017-05-23 at 4 19 51 pm" src="https://cloud.githubusercontent.com/assets/139536/26347413/b5f03244-3fd3-11e7-85e4-bfe2b6ce44cd.png">
