### PR TITLE
Upgrade build tools SDK

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     repositories {
         jcenter()
     }
-    
+
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
     }
@@ -12,7 +12,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "25.0.3"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
There have been 12 months of bugfixes since v23 of the build tools SDK,
so this brings it up-to-date (as of April 2017).