### PR TITLE
Search for `_` globally

### DIFF
--- a/vendor/i18n.js
+++ b/vendor/i18n.js
@@ -642,7 +642,7 @@
       var s = scope.split('.').slice(-1)[0];
       //replace underscore with space && camelcase with space and lowercase letter
       return (this.missingTranslationPrefix.length > 0 ? this.missingTranslationPrefix : '') +
-          s.replace('_',' ').replace(/([a-z])([A-Z])/g,
+          s.replace(/_/g,' ').replace(/([a-z])([A-Z])/g,
           function(match, p1, p2) {return p1 + ' ' + p2.toLowerCase()} );
     }
 


### PR DESCRIPTION
Fix behaviour of guessing translation to comply with https://github.com/fnando/i18n-js

> Camel case becomes lower cased text and underscores are replaced with space
> `questionnaire.whatIsYourFavorite_ChristmasPresent`
> becomes
> `"what is your favorite Christmas present"`

According to [the documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace): "To perform a global search and replace, include the g switch in the regular expression."