### PR TITLE
replace react-native RNI18n to SettingsManager

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ import { NativeModules } from 'react-native';
 import I18n from 'i18n-js';
 const { RNI18n } = NativeModules;
 
-I18n.locale = RNI18n.languages[0];
+I18n.locale = NativeModules.SettingsManager.settings.AppleLocale
 
 export const getLanguages = RNI18n.getLanguages;
 export default I18n;


### PR DESCRIPTION
RNI18n miss after react-native 0.42
get app locale from SettingsManager