### PR TITLE
use latest version for  i18n-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "i18n"
   ],
   "dependencies": {
-    "i18n-js": "github:fnando/i18n-js#v3.0.0"
+    "i18n-js": "github:fnando/i18n-js#v3.0.1"
   }
 }


### PR DESCRIPTION
3.0.1 - 2017-08-02

Changed

[Ruby] Relax Rails detection code to work with alternative installation methods
(PR: https://github.com/fnando/i18n-js/pull/467)
[JS] Fix fallback when "3-part" locale like zh-Hant-TW is used
It fallbacks to zh only before, now it fallbacks to zh-Hant
(PR: https://github.com/fnando/i18n-js/pull/465)