### PR TITLE
Added default value for locale and getLanguages

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,9 @@
 const RNI18n = require('react-native').NativeModules.RNI18n;
 const I18nJs = require('i18n-js');
 
-I18nJs.locale = RNI18n.languages[0];
-export const getLanguages = RNI18n.getLanguages;
+I18nJs.locale = RNI18n ? RNI18n.languages[0] : 'en';
+export const getLanguages = RNI18n ? RNI18n.getLanguages : new Promise((resolve, reject) => {
+    resolve('en');
+});
+
 export default I18nJs;


### PR DESCRIPTION
Fix error Undefined is not an object (evaluating 'RNI18n.languages') in Expo (ios, android)