### PR TITLE
Fix RN 0.48+ warning about requiresMainQueueSetup

### DIFF
--- a/ios/RNI18n.m
+++ b/ios/RNI18n.m
@@ -5,6 +5,10 @@
 
 RCT_EXPORT_MODULE();
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
 - (NSMutableArray *)toLanguageTags:(NSArray *)languages {
   NSMutableArray *languageTags = [NSMutableArray array];
 


### PR DESCRIPTION
Warning: Module RNI18n requires main queue setup since it overrides constantsToExport but doesn't implement `requiresMainQueueSetup. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.