### PR TITLE
fix android generating old language code for ISO 639

### DIFF
--- a/android/src/main/java/com/AlexanderZaytsev/RNI18n/RNI18nModule.java
+++ b/android/src/main/java/com/AlexanderZaytsev/RNI18n/RNI18nModule.java
@@ -26,19 +26,24 @@ public class RNI18nModule extends ReactContextBaseJavaModule {
   }
 
   private String toLanguageTag(Locale locale) {
+    String langTag;
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      return locale.toLanguageTag();
+      langTag = locale.toLanguageTag();
+    } else {
+      StringBuilder builder = new StringBuilder();
+      builder.append(locale.getLanguage());
+
+      if (locale.getCountry() != null) {
+        builder.append("-");
+        builder.append(locale.getCountry());
+      }
+
+      langTag = builder.toString();
     }
-
-    StringBuilder builder = new StringBuilder();
-    builder.append(locale.getLanguage());
-
-    if (locale.getCountry() != null) {
-      builder.append("-");
-      builder.append(locale.getCountry());
+    if (langTag.matches("^(iw|in|ji).*")){
+      return langTag.replace("iw","he").replace("in","id").replace("ji","yi");
     }
-
-    return builder.toString();
+    return langTag;
   }
 
   private WritableArray getLocaleList() {


### PR DESCRIPTION
forLanguageTag not converting old ISO 649 format to new as described :
The language codes "he", "yi", and "id" are mapped to "iw", "ji", and "in" respectively. (This is the same canonicalization that's done in Locale's constructors.) 
due to:
ISO 639 is not a stable standard; some of the language codes it defines (specifically "iw", "ji", and "in") have changed. This constructor accepts both the old codes ("iw", "ji", and "in") and the new codes ("he", "yi", and "id"), but all other API on Locale will return only the OLD codes.
this android issue also described here:
https://stackoverflow.com/questions/44245959/android-generating-wrong-language-code-for-indonesia

my workaround is similar to one was implemented for OneSignal project
https://github.com/OneSignal/OneSignal-Android-SDK/commit/7b9caf56335649519da107f0c696ca40bdd97bc7