### PR TITLE
Fix RNI18n.podspec to avoid "Error installing RNI18n"

### DIFF
--- a/RNI18n.podspec
+++ b/RNI18n.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author       = { "Alexander Zaytsev" => "alexander@say26.com" }
   s.ios.deployment_target = "7.0"
   s.tvos.deployment_target = "9.0"
-  s.source       = { git: "https://github.com/AlexanderZaytsev/react-native-i18n.git", tag: s.version.to_s }
+  s.source       = { git: "https://github.com/AlexanderZaytsev/react-native-i18n.git", tag: "v" + s.version.to_s }
   s.source_files = "ios/**/*.{h,m}"
   s.requires_arc = true
 


### PR DESCRIPTION
I had the following issue while installing this package into my Podfile:
```
Installing RNI18n (2.0.12)

[!] Error installing RNI18n
[!] /usr/bin/git clone https://github.com/AlexanderZaytsev/react-native-i18n.git /var/folders/f8/thkggm6d46vbcft0k5fh8_qh0000gn/T/d20180622-89871-ox9uho --template= --single-branch --depth 1 --branch 2.0.12

Cloning into '/var/folders/f8/thkggm6d46vbcft0k5fh8_qh0000gn/T/d20180622-89871-ox9uho'...
warning: Could not find remote branch 2.0.12 to clone.
fatal: Remote branch 2.0.12 not found in upstream origin
```

package.json contains version as `"version": "2.0.12",`, however the tags named as `v2.0.12`.