### PR TITLE
support default gradle version coming with RN

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,5 +28,5 @@ android {
 
 dependencies {
     //noinspection GradleDynamicVersion
-    implementation "com.facebook.react:react-native:${_reactNativeVersion}"
+    compile "com.facebook.react:react-native:${_reactNativeVersion}"
 }


### PR DESCRIPTION
Project created by `react-native init ..` won't compile because implementation() is not supported by specified gradle version