### PR TITLE
Remove Gradle warning

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,5 +22,5 @@ android {
 }
 
 dependencies {
-  compile "com.facebook.react:react-native:+" // From node_modules
+  implementation "com.facebook.react:react-native:+" // From node_modules
 }


### PR DESCRIPTION
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html