### PR TITLE
remove-AndroidManifest-minSdkVersion

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.AlexanderZaytsev.RNI18n">
-    <uses-sdk android:minSdkVersion="16" />
 </manifest>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-i18n",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "description": "Provide I18n to your React Native application",
   "license": "MIT",
   "author": "Alexander Zaytsev",


### PR DESCRIPTION
remove minSdkVersion from react-native-i18n/android/src/main/AndroidManifest.xml
because it is an error in Android Studio 3.0+