### PR TITLE
removed minSDKVersion from Manifest file

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.AlexanderZaytsev.RNI18n">
-    <uses-sdk android:minSdkVersion="16" />
 </manifest>


### PR DESCRIPTION
android compile fails with `minSdkVersion` in Manifest.xml
related issuues https://github.com/AlexanderZaytsev/react-native-i18n/issues/249