### PR TITLE
replace deprecated compile into implementation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,5 +22,5 @@ android {
 }
 
 dependencies {
-  compile "com.facebook.react:react-native:+" // From node_modules
+  implementation "com.facebook.react:react-native:+" // From node_modules
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.AlexanderZaytsev.RNI18n">
-    <uses-sdk android:minSdkVersion="16" />
 </manifest>


### PR DESCRIPTION
`compile` is deprecated, replaced by `implementation`