### PR TITLE
minSdk version should not be declared in the android manifest file

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.AlexanderZaytsev.RNI18n">
-    <uses-sdk android:minSdkVersion="16" />
 </manifest>


### PR DESCRIPTION
The minSdk version should not be declared in the android manifest file. You can move the version from the manifest to the defaultConfig in the build.gradle file.

<img width="879" alt="Screenshot 2020-08-06 at 13 52 09" src="https://user-images.githubusercontent.com/4986411/89528975-3df5e400-d7ec-11ea-9d0c-06c60f604e37.png">
