### PR TITLE
Fix Xcode 12 compatibility

### DIFF
--- a/RNI18n.podspec
+++ b/RNI18n.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m}"
   s.requires_arc = true
 
-  s.dependency "React"
+  s.dependency "React-Core"
 end


### PR DESCRIPTION
Compilation fails on Xcode 12 with `Undefined symbols for architecture` errors, due to the React dependency in the podspec.

See the react-native issue here - https://github.com/facebook/react-native/issues/29633#issuecomment-694187116