### PR TITLE
Fix to support gradle 7

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,5 +22,5 @@ android {
 }
 
 dependencies {
-  compile "com.facebook.react:react-native:+" // From node_modules
+  implementation "com.facebook.react:react-native:+" // From node_modules
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,5 +22,5 @@ android {
 }
 
 dependencies {
-  implementation "com.facebook.react:react-native:+" // From node_modules
+  implementation('com.facebook.react:react-native:+')
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-i18n",
-  "version": "2.0.15",
+  "version": "2.0.15-patched",
   "description": "Provide I18n to your React Native application",
   "license": "MIT",
   "author": "Alexander Zaytsev",


### PR DESCRIPTION
Update the attribute from `compile` to `implementation` for gradle7+. 
React Native 68+ uses gradle 7.